### PR TITLE
add chrome 74 browser support to cypress

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,12 @@
-FROM cypress/base:10
+FROM cypress/browsers:node10.2.1-chrome74
 
+ENV PATH="${PATH}:/app/node_modules/.bin"
 WORKDIR /app
 
 COPY ./package.json /app
 COPY ./yarn.lock /app
 
 RUN yarn install
-RUN $(npm bin)/cypress verify
+RUN cypress verify
 
-CMD $(npm bin)/cypress run
+CMD cypress run

--- a/README.md
+++ b/README.md
@@ -15,7 +15,12 @@ The default command will be `cypress run`.
 
 ```
 - docker run --rm -v ${PWD}/cypress-e2e/cypress:/app/cypress -v ${PWD}/cypress-e2e/cypress.json:/app/cypress.json -v ${PWD}/cypress-e2e/package.json:/app/package.json --network="host" ambientinnovation/cypress-docker
+```
 
+If you want to run cypress via Chrome 74 instead of Electron 61 you can run cypress with the optional browser flag set to chrome.
+
+ ```
+ - docker run --rm -v ${PWD}/cypress-e2e/cypress:/app/cypress -v ${PWD}/cypress-e2e/cypress.json:/app/cypress.json -v ${PWD}/cypress-e2e/package.json:/app/package.json --network="host" ambientinnovation/cypress-docker  cypress run --browser chrome
 ```
 
 ## Development


### PR DESCRIPTION
Those changes allow cypress to run via chrome 74 by using the optional `--browser chrome` flag. For further explanations how  to use this flag specifically, the `README.md` is extended.

The `/app/node_modules/.bin` folder is added to the `$PATH` variable for allowing to call `cypress run --browser chrome` as docker parameter because otherwise the user has to write the whole path to the executable. 